### PR TITLE
feat: add command to fetch render tree by widget type

### DIFF
--- a/demo-app/android/build.gradle
+++ b/demo-app/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.7.10'
+    ext.kotlin_version = '1.8.22'
     repositories {
         google()
         mavenCentral()

--- a/demo-app/android/gradle/wrapper/gradle-wrapper.properties
+++ b/demo-app/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip

--- a/demo-app/pubspec.yaml
+++ b/demo-app/pubspec.yaml
@@ -20,7 +20,7 @@ environment:
 # versions available, run `flutter pub outdated`.
 dependencies:
   webview_flutter: ^4.5.0
-  carousel_slider: ^4.2.1
+  carousel_slider: ^5.0.0
   permission_handler: ^11.3.1
   url_launcher: ^6.3.0
   qr_code_dart_scan: ^0.8.1

--- a/server/lib/src/handler/get_render_tree.dart
+++ b/server/lib/src/handler/get_render_tree.dart
@@ -17,15 +17,6 @@ class GetRenderTreeByTypeHandler extends RequestHandler {
     final text = queryParams['text'];
     final key = queryParams['key'];
 
-    if (widgetType == null || widgetType.isEmpty) {
-      return AppiumResponse.withError(
-        getSessionId(request),
-        'Missing required parameter: widgetType',
-        null,
-        HttpStatus.badRequest,
-      );
-    }
-
     try {
       final elements = await ElementHelper.getRenderTreeByType(
         widgetType: widgetType,

--- a/server/lib/src/handler/get_render_tree.dart
+++ b/server/lib/src/handler/get_render_tree.dart
@@ -1,0 +1,46 @@
+import 'dart:io';
+
+import 'package:appium_flutter_server/src/handler/request/request_handler.dart';
+import 'package:appium_flutter_server/src/models/api/appium_response.dart';
+import 'package:appium_flutter_server/src/utils/element_helper.dart';
+
+import 'package:shelf_plus/shelf_plus.dart';
+
+class GetRenderTreeByTypeHandler extends RequestHandler {
+  GetRenderTreeByTypeHandler(super.route);
+
+  @override
+  Future<AppiumResponse> handle(Request request) async {
+    final queryParams = request.url.queryParameters;
+
+    final widgetType = queryParams['widgetType'];
+    final text = queryParams['text'];
+    final key = queryParams['key'];
+
+    if (widgetType == null || widgetType.isEmpty) {
+      return AppiumResponse.withError(
+        getSessionId(request),
+        'Missing required parameter: widgetType',
+        null,
+        HttpStatus.badRequest,
+      );
+    }
+
+    try {
+      final elements = await ElementHelper.getRenderTreeByType(
+        widgetType: widgetType,
+        text: text,
+        key: key,
+      );
+
+      return AppiumResponse(getSessionId(request), elements);
+    } catch (e) {
+      return AppiumResponse.withError(
+        getSessionId(request),
+        'Error: ${e.toString()}',
+        null,
+        HttpStatus.internalServerError,
+      );
+    }
+  }
+}

--- a/server/lib/src/handler/render_tree.dart
+++ b/server/lib/src/handler/render_tree.dart
@@ -6,25 +6,25 @@ import 'package:appium_flutter_server/src/utils/element_helper.dart';
 
 import 'package:shelf_plus/shelf_plus.dart';
 
-class GetRenderTreeByTypeHandler extends RequestHandler {
-  GetRenderTreeByTypeHandler(super.route);
+class RenderTreeHandler extends RequestHandler {
+  RenderTreeHandler(super.route);
 
   @override
   Future<AppiumResponse> handle(Request request) async {
-    final queryParams = request.url.queryParameters;
+    final Map<String, dynamic>? bodyParams = await request.body.asJson;
 
-    final widgetType = queryParams['widgetType'];
-    final text = queryParams['text'];
-    final key = queryParams['key'];
+    final String? widgetType = bodyParams?['widgetType'] as String?;
+    final String? text = bodyParams?['text'] as String?;
+    final String? key = bodyParams?['key'] as String?;
 
     try {
-      final elements = await ElementHelper.getRenderTreeByType(
+      final widgetTree = await ElementHelper.getRenderTreeByType(
         widgetType: widgetType,
         text: text,
         key: key,
       );
 
-      return AppiumResponse(getSessionId(request), elements);
+      return AppiumResponse(getSessionId(request), widgetTree);
     } catch (e) {
       return AppiumResponse.withError(
         getSessionId(request),

--- a/server/lib/src/runner.dart
+++ b/server/lib/src/runner.dart
@@ -10,7 +10,7 @@ import 'package:package_info_plus/package_info_plus.dart';
 const MAX_TEST_DURATION_SECS = 24 * 60 * 60;
 // Need a better way to fetch this for automated release, this needs to be updated along with version bump
 // Can stay for now as it is not a breaking change
-const serverVersion = '0.0.27';
+const serverVersion = '0.0.28';
 
 void initializeTest({Widget? app, Function? callback}) async {
   IntegrationTestWidgetsFlutterBinding binding =

--- a/server/lib/src/server.dart
+++ b/server/lib/src/server.dart
@@ -12,6 +12,7 @@ import 'package:appium_flutter_server/src/handler/gesture/scroll_till_visible.da
 import 'package:appium_flutter_server/src/handler/get_attribute.dart';
 import 'package:appium_flutter_server/src/handler/get_name.dart';
 import 'package:appium_flutter_server/src/handler/get_rect.dart';
+import 'package:appium_flutter_server/src/handler/get_render_tree.dart';
 import 'package:appium_flutter_server/src/handler/get_size.dart';
 import 'package:appium_flutter_server/src/handler/get_text.dart';
 import 'package:appium_flutter_server/src/handler/new_session.dart';
@@ -65,6 +66,8 @@ class FlutterServer {
     _registerGet(GetRectHandler("/session/<sessionId>/element/<id>/rect"));
     _registerGet(GetSizeHandler("/session/<sessionId>/element/<id>/size"));
     _registerGet(GetNameHandler("/session/<sessionId>/element/<id>/name"));
+    _registerGet(GetRenderTreeByTypeHandler(
+        "/session/<sessionId>/element/render_tree"));
 
     //POST ROUTES
     _registerPost(SetTextHandler("/session/<sessionId>/element/<id>/value"));

--- a/server/lib/src/server.dart
+++ b/server/lib/src/server.dart
@@ -12,7 +12,7 @@ import 'package:appium_flutter_server/src/handler/gesture/scroll_till_visible.da
 import 'package:appium_flutter_server/src/handler/get_attribute.dart';
 import 'package:appium_flutter_server/src/handler/get_name.dart';
 import 'package:appium_flutter_server/src/handler/get_rect.dart';
-import 'package:appium_flutter_server/src/handler/get_render_tree.dart';
+import 'package:appium_flutter_server/src/handler/render_tree.dart';
 import 'package:appium_flutter_server/src/handler/get_size.dart';
 import 'package:appium_flutter_server/src/handler/get_text.dart';
 import 'package:appium_flutter_server/src/handler/new_session.dart';
@@ -66,8 +66,6 @@ class FlutterServer {
     _registerGet(GetRectHandler("/session/<sessionId>/element/<id>/rect"));
     _registerGet(GetSizeHandler("/session/<sessionId>/element/<id>/size"));
     _registerGet(GetNameHandler("/session/<sessionId>/element/<id>/name"));
-    _registerGet(GetRenderTreeByTypeHandler(
-        "/session/<sessionId>/element/render_tree"));
 
     //POST ROUTES
     _registerPost(SetTextHandler("/session/<sessionId>/element/<id>/value"));
@@ -75,13 +73,15 @@ class FlutterServer {
     _registerPost(NewSessionHandler("/session"));
     _registerPost(FindElementHandler("/session/<sessionId>/element"));
     _registerPost(FindElementstHandler("/session/<sessionId>/elements"));
+    _registerPost(
+        RenderTreeHandler("/session/<sessionId>/element/render_tree"));
     _registerPost(ClickHandler("/session/<sessionId>/element/<id>/click"));
     _registerPost(
         DoubleClickHandler("/session/<sessionId>/element/<id>/double_click"));
     _registerPost(PressBackHandler("/session/<sessionId>/back"));
     _registerPost(InjectImage("/session/<sessionId>/inject_image"));
-    _registerPost(ActivateInjectImage("/session/<sessionId>/activate_inject_image"));
-
+    _registerPost(
+        ActivateInjectImage("/session/<sessionId>/activate_inject_image"));
     /* Gesture handler */
     _registerPost(
         LongPressHandler("/session/<sessionId>/appium/gestures/long_press"));

--- a/server/lib/src/utils/ui_serialization/element_serializer.dart
+++ b/server/lib/src/utils/ui_serialization/element_serializer.dart
@@ -1,0 +1,154 @@
+import 'package:appium_flutter_server/src/internal/flutter_element.dart';
+import 'package:appium_flutter_server/src/utils/element_helper.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class ElementSerializer {
+  static Future<Map<String, dynamic>> serialize(
+    Element element, {
+    Set<Element>? visited,
+    int depth = 0,
+  }) async {
+    visited ??= <Element>{};
+    if (visited.contains(element)) {
+      return {};
+    }
+    visited.add(element);
+
+    final widget = element.widget;
+    final renderObject = element.renderObject;
+    final rect = renderObject?.paintBounds;
+
+    final children =
+        await _serializeChildren(element, visited: visited, depth: depth);
+
+    final attributes = await _serializeAttributes(widget);
+    final visualProperties = await _serializeVisualProperties(widget);
+    final stateProperties = _serializeStateProperties(widget);
+
+    return {
+      'type': widget.runtimeType.toString(),
+      'elementType': element.runtimeType.toString(),
+      'description': widget.toStringShort(),
+      'depth': depth,
+      if (widget.key != null) 'key': widget.key.toString(),
+      'attributes': attributes,
+      'visual': visualProperties,
+      'state': stateProperties,
+      if (rect != null)
+        'rect': {
+          'x': rect.left,
+          'y': rect.top,
+          'width': rect.width,
+          'height': rect.height,
+        },
+      'children': children,
+    };
+  }
+
+  static Future<List<Map<String, dynamic>>> _serializeChildren(
+    Element element, {
+    required Set<Element> visited,
+    required int depth,
+  }) async {
+    final List<Map<String, dynamic>> children = [];
+    final List<Future<Map<String, dynamic>>> childrenFutures = [];
+    element.visitChildren((child) {
+      childrenFutures.add(serialize(child, visited: visited, depth: depth + 1));
+    });
+    final resolvedChildren = await Future.wait(childrenFutures);
+    for (final childJson in resolvedChildren) {
+      if (childJson.isNotEmpty) {
+        children.add(childJson);
+      }
+    }
+    return children;
+  }
+
+  static Future<Map<String, String?>> _serializeAttributes(
+      Widget widget) async {
+    String? text;
+    try {
+      final flutterElement = FlutterElement.fromBy(find.byWidget(widget));
+      text = await ElementHelper.getText(flutterElement);
+    } catch (_) {
+      text = null;
+    }
+
+    String? semanticsLabel;
+    String? tooltip;
+    String? hintText;
+
+    if (widget is Semantics) {
+      semanticsLabel = widget.properties.label;
+    } else if (widget is Tooltip) {
+      tooltip = widget.message;
+    } else if (widget is TextField) {
+      hintText = widget.decoration?.hintText;
+    }
+
+    return {
+      if (text?.isNotEmpty ?? false) 'text': text,
+      if (semanticsLabel != null) 'semanticsLabel': semanticsLabel,
+      if (tooltip != null) 'tooltip': tooltip,
+      if (hintText != null) 'hintText': hintText,
+    };
+  }
+
+  static Future<Map<String, dynamic>> _serializeVisualProperties(
+      Widget widget) async {
+    double? fontSize;
+    String? fontWeight;
+    String? fontStyle;
+    String? backgroundColor;
+    String? color;
+
+    if (widget is Text) {
+      final style = widget.style;
+      fontSize = style?.fontSize;
+      fontWeight = style?.fontWeight?.toString();
+      fontStyle = style?.fontStyle?.toString();
+      color = style?.color?.toString();
+    } else if (widget is Container) {
+      if (widget.decoration is BoxDecoration) {
+        backgroundColor =
+            (widget.decoration as BoxDecoration).color?.toString();
+      }
+    } else if (widget is ElevatedButton) {
+      final backgroundColorProperty = widget.style?.backgroundColor;
+      final resolvedColor = backgroundColorProperty?.resolve(<WidgetState>{});
+      if (resolvedColor != null) {
+        backgroundColor = resolvedColor.toString();
+      }
+    }
+
+    return {
+      if (fontSize != null) 'fontSize': fontSize,
+      if (fontWeight != null) 'fontWeight': fontWeight,
+      if (fontStyle != null) 'fontStyle': fontStyle,
+      if (backgroundColor != null) 'backgroundColor': backgroundColor,
+      if (color != null) 'color': color,
+    };
+  }
+
+  static Map<String, dynamic> _serializeStateProperties(Widget widget) {
+    bool? enabled;
+    bool? focused;
+    bool? visible;
+
+    if (widget is EditableText) {
+      focused = widget.focusNode.hasFocus;
+    } else if (widget is TextField) {
+      enabled = widget.enabled ?? true;
+      focused = widget.focusNode?.hasFocus ?? false;
+    } else if (widget is Visibility) {
+      visible = widget.visible;
+    }
+
+    return {
+      if (enabled != null) 'enabled': enabled,
+      if (focused != null) 'focused': focused,
+      if (visible != null) 'visible': visible,
+    };
+  }
+}


### PR DESCRIPTION
Hi there,

Thank you for this amazing project!

This PR introduces a method for retrieving the render tree of widgets based on the widget type, with optional filtering by key or text.

The implementation works well and is conceptually similar to the GetRenderTree method from FlutterDriver, but offers more flexibility thanks to its parameterized approach.

Here are some examples of successful responses:

with params widgetType & key

```
[5591d3a3][WD Proxy] Proxying [GET /session/5591d3a3-9cba-47fd-ae8b-39d23792e241/element/render_tree?widgetType=ElevatedButton&key=LoginButton] to [GET http://127.0.0.1:10002/session/44008ba4-22c8-489a-9e9e-61a9804e3620/element/render_tree?widgetType=ElevatedButton&key=LoginButton] with no body
[5591d3a3][WD Proxy] Got response with status 200: {"sessionId":"44008ba4-22c8-489a-9e9e-61a9804e3620","value":[{"type":"ElevatedButton","rect":{"x":0,"y":0,"width":378.6666666666667,"height":48},"children":[{"type":"Semantics","rect":{"x":0,"y":0,"width":378.6666666666667,"height":48},"children":[{"type":"_InputPadding","rect":{"x":0,"y":0,"width":378.6666666666667,"height":48},"children":[{"type":"ConstrainedBox","rect":{"x":0,"y":0,"width":378.6666666666667,"height":40},"children":[{"type":"Material","rect":{"x":0,"y":0,"width":378.6666666666667,"height":40},"children":[{"type":"_MaterialInterior","rect":{"x":0,"y":0,"width":378.6666666666667,"height":40},"children":[{"type":"PhysicalShape","rect":{"x":0,"y":0,"width":378.6666666666667,"height":40},"children":[{"type":"_ShapeBorderPaint","rect":{"x":0,"y":0,"width":378.6666666666667,"height":40},"children":[{"type":"CustomPaint","rect":{"x":0,"y":0,"width":378.6666666666667,"height":40},"children":[{"type":"NotificationListener<LayoutChangedNotification>","rect":{"x":0,"y":0,"width":378.6666666666667,"h...
[5591d3a3][AppiumFlutterDriver@a01a] Responding to client with driver.execute() result: [{"type":"ElevatedButton","rect":{"x":0,"y":0,"width":378.6666666666667,"height":48},"children":[{"type":"Semantics","rect":{"x":0,"y":0,"width":378.6666666666667,"height":48},"children":[{"type":"_InputPadding","rect":{"x":0,"y":0,"width":378.6666666666667,"height":48},"children":[{"type":"ConstrainedBox","rect":{"x":0,"y":0,"width":378.6666666666667,"height":40},"children":[{"type":"Material","rect":{"x":0,"y":0,"width":378.6666666666667,"height":40},"children":[{"type":"_MaterialInterior","rect":{"x":0,"y":0,"width":378.6666666666667,"height":40},"children":[{"type":"PhysicalShape","rect":{"x":0,"y":0,"width":378.6666666666667,"height":40},"children":[{"type":"_ShapeBorderPaint","rect":{"x":0,"y":0,"width":378.6666666666667,"height":40},"children":[{"type":"CustomPaint","rect":{"x":0,"y":0,"width":378.6666666666667,"height":40},"children":[{"type":"NotificationListener<LayoutChangedNotification>","rect":{"x":0,"y":0,"width":378.6666666666667,"height":40},"children":[{"type":"_InkFeatures","rect":{"x":0,...
```

with param widgetType

```
[fd2f75ee][HTTP] --> POST /session/fd2f75ee-169a-4d0c-8560-acbaa2cec91d/execute/sync {"script":"flutter: getRenderTreeByType","args":[{"widgetType":"LoginScreen"}]}
[fd2f75ee][AppiumFlutterDriver@dba5] Calling AppiumDriver.execute() with args: ["flutter: getRenderTreeByType",[{"widgetType":"LoginScreen"}],"fd2f75ee-169a-4d0c-8560-acbaa2cec91d"]
[fd2f75ee][WD Proxy] Proxying [GET /session/fd2f75ee-169a-4d0c-8560-acbaa2cec91d/element/render_tree?widgetType=LoginScreen] to [GET http://127.0.0.1:10002/session/e759d23a-3673-4186-98e7-01eaf7c31612/element/render_tree?widgetType=LoginScreen] with no body
[fd2f75ee][WD Proxy] Got response with status 200: {"sessionId":"e759d23a-3673-4186-98e7-01eaf7c31612","value":[{"type":"LoginScreen","rect":{"x":0,"y":0,"width":426.6666666666667,"height":928},"children":[{"type":"Scaffold","rect":{"x":0,"y":0,"width":426.6666666666667,"height":928},"children":[{"type":"_ScaffoldScope","rect":{"x":0,"y":0,"width":426.6666666666667,"height":928},"children":[{"type":"ScrollNotificationObserver","rect":{"x":0,"y":0,"width":426.6666666666667,"height":928},"children":[{"type":"NotificationListener<ScrollMetricsNotification>","rect":{"x":0,"y":0,"width":426.6666666666667,"height":928},"children":[{"type":"NotificationListener<ScrollNotification>","rect":{"x":0,"y":0,"width":426.6666666666667,"height":928},"children":[{"type":"_ScrollNotificationObserverScope","rect":{"x":0,"y":0,"width":426.6666666666667,"height":928},"children":[{"type":"Material","rect":{"x":0,"y":0,"width":426.6666666666667,"height":928},"children":[{"type":"AnimatedPhysicalModel","rect":{"x":0,"y":0,"width":426.6666666666667,"height":928},"children":[{"type...
[fd2f75ee][AppiumFlutterDriver@dba5] Responding to client with driver.execute() result: [{"type":"LoginScreen","rect":{"x":0,"y":0,"width":426.6666666666667,"height":928},"children":[{"type":"Scaffold","rect":{"x":0,"y":0,"width":426.6666666666667,"height":928},"children":[{"type":"_ScaffoldScope","rect":{"x":0,"y":0,"width":426.6666666666667,"height":928},"children":[{"type":"ScrollNotificationObserver","rect":{"x":0,"y":0,"width":426.6666666666667,"height":928},"children":[{"type":"NotificationListener<ScrollMetricsNotification>","rect":{"x":0,"y":0,"width":426.6666666666667,"height":928},"children":[{"type":"NotificationListener<ScrollNotification>","rect":{"x":0,"y":0,"width":426.6666666666667,"height":928},"children":[{"type":"_ScrollNotificationObserverScope","rect":{"x":0,"y":0,"width":426.6666666666667,"height":928},"children":[{"type":"Material","rect":{"x":0,"y":0,"width":426.6666666666667,"height":928},"children":[{"type":"AnimatedPhysicalModel","rect":{"x":0,"y":0,"width":426.6666666666667,"height":928},"children":[{"type":"PhysicalModel","rect":{"x":0,"y":0,"width":426.6666666666...
```

In the future, the structure can be improved and an optional depth parameter could be added.

This PR addresses and implements the related feature request
https://github.com/AppiumTestDistribution/appium-flutter-integration-driver/issues/116
