### PR TITLE
chore: bump version of path

### DIFF
--- a/server/pubspec.yaml
+++ b/server/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   a_bridge: ^0.0.2
   device_info_plus: any
   image_picker: ^1.1.2
-  path: 1.9.1
+  path: ^1.9.0
   permission_handler: any
   image_picker_platform_interface: any
 


### PR DESCRIPTION
Bumps version of dependency to match SDK for flutter 3.32.5