### PR TITLE
Find element work for non hitTestable elements.

### DIFF
--- a/server/lib/src/utils/element_helper.dart
+++ b/server/lib/src/utils/element_helper.dart
@@ -26,8 +26,25 @@ class ElementHelper {
   static Future<Finder> findElement(Finder by, {String? contextId}) async {
     List<Finder> elementList =
         await findElements(by, contextId: contextId, evaluatePresence: true);
-    log("Element found ${elementList.first}");
+    final Finder? hitTestableElement =
+        getFirstHitTestableElementIfPresent(elementList);
+    if (hitTestableElement != null) {
+      log("The hitTestable element found $hitTestableElement");
+      return hitTestableElement;
+    }
+    log("The non-hitTestable element found ${elementList.first}");
     return elementList.first;
+  }
+
+  static Finder? getFirstHitTestableElementIfPresent(List<Finder> elementList) {
+    for (Finder element in elementList) {
+      try {
+        if (element.hitTestable().tryEvaluate()) {
+          return element;
+        }
+      } catch (_) {}
+    }
+    return null;
   }
 
   static Future<List<Finder>> findElements(Finder by,
@@ -42,7 +59,6 @@ class ElementHelper {
 
       finder = find.descendant(of: parent.by, matching: by);
     }
-    finder = finder.hitTestable();
     final FinderResult<Element> elements = finder.evaluate();
     if (evaluatePresence) {
       await waitForElementExist(FlutterElement.fromBy(finder),
@@ -57,9 +73,35 @@ class ElementHelper {
 
     List<Finder> elementList = [];
     for (int i = 0; i < elements.length; i++) {
-      elementList.add(finder.at(i));
+      if (isVisibleOnAppScreen(elements.elementAt(i))) {
+        elementList.add(finder.at(i));
+      }
     }
     return elementList;
+  }
+
+  static bool isVisibleOnAppScreen(Element finderElement) {
+    if (finderElement.renderObject is! RenderBox) {
+      return true;
+    }
+    final WidgetTester tester = _getTester();
+    final widgetRect =
+        tester.getRect(find.byElementPredicate((e) => e == finderElement));
+
+    final allWidgets = tester.allWidgets.toList();
+
+    for (final widget in allWidgets) {
+      final elements = find.byWidget(widget).evaluate();
+      for (final element in elements) {
+        if (element.renderObject is RenderBox) {
+          final rootRect = tester.getRect(
+            find.byElementPredicate((e) => e == element),
+          );
+          return widgetRect.overlaps(rootRect);
+        }
+      }
+    }
+    return false;
   }
 
   static Future<void> click(FlutterElement element) async {


### PR DESCRIPTION
Hello!

I’d like to suggest some improvements to the library. > Our team has been using this approach for over a year now, and it has been working perfectly for us in production.

**Subject**: Improve visibility detection by adding a fallback for non-RenderBox elements

Description:
This PR enhances the visibility check logic to handle cases where `hitTestable()` might incorrectly return false for elements that are technically present on the screen.

While `hitTestable() `is effective for standard interactive elements, it has limitations in the following scenarios:

**Non-RenderBox Elements**: Widgets like `SliverList`, `SliverGrid`, `InheritedWidget`, or `Builder` do not have a `RenderBox`. The proposed logic ensures that if a `RenderObject` is not a `RenderBox`, we treat it as visible to allow traversal of its children.

**Pointer Interactivity**: Elements wrapped in `IgnorePointer` are visually present but fail hit-testing by design.

**Edge Cases with Opacity & HitTestBehavior**: Depending on the HitTestBehavior, elements with specific hit-test configurations might be skipped by hitTestable() even if they exist in the tree and visible on the screen.

**Offstage Widgets**: Provides a more predictable way to distinguish between widgets that are simply off-screen versus those explicitly hidden via Offstage.

**Conclusion**:
The `isVisibleOnAppScreen()` method acts as a necessary fallback. It ensures that the library doesn't skip elements that are visually or structurally important but "invisible" to the standard pointer-based hit-testing mechanism.